### PR TITLE
Add CFBundleExecutable Info.plist key

### DIFF
--- a/ExtrudeTool.glyphsTool/Contents/Info.plist
+++ b/ExtrudeTool.glyphsTool/Contents/Info.plist
@@ -6,6 +6,8 @@
 	<string>20D64</string>
 	<key>CFBundleDisplayName</key>
 	<string>ExtrudeTool</string>
+	<key>CFBundleExecutable</key>
+	<string>ExtrudeTool</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.danielgamage.ExtrudeTool</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
The plugin also runs without this key, but I would include it just be on the save side.